### PR TITLE
Add Open Graph images for about pages

### DIFF
--- a/about/2023AprFWBK/index.html
+++ b/about/2023AprFWBK/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Apr Fashion Week Brooklyn - CENSORED SS23 Collection, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2023AprFWBK/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2023AprZeus/index.html
+++ b/about/2023AprZeus/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Apr ZEUS - CENSORED SS23 Collection, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2023AprZeus/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2023AugJapanVillage/index.html
+++ b/about/2023AugJapanVillage/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Aug Japan Village - Million Dollar Bag Debut, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2023AugJapanVillage/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2023DecParkMart/index.html
+++ b/about/2023DecParkMart/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Dec ParkMart - Fashion Pop-Up, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2023DecParkMart/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2023OctFWBK/index.html
+++ b/about/2023OctFWBK/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Oct Fashion Week Brooklyn - POWER NAP Collection, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2023OctFWBK/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2023SepTosh/index.html
+++ b/about/2023SepTosh/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Sep TOSH - CASH ME IF YOU CAN Collection, New York, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2023SepTosh/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2024FebFWBKLondon/index.html
+++ b/about/2024FebFWBKLondon/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2024 Feb Fashion Week Brooklyn - POWER NAP Collection, London, United Kingdom</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2024FebFWBKLondon/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2024FebFWBKParis/index.html
+++ b/about/2024FebFWBKParis/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2024 Feb Fashion Week Brooklyn - POWER NAP Collection, Paris, France</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2024FebFWBKParis/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2024NovRunway27/index.html
+++ b/about/2024NovRunway27/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2024 Nov Runway 27 - TV Backpack, Fashion Institute of Technology, New York, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2024NovRunway27/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;

--- a/about/2024OctFWBK/index.html
+++ b/about/2024OctFWBK/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8"/>
 <title>2024 Oct Fashion Week Brooklyn - PLUGGED IN TOO Collection, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta property="og:image" content="https://www.richardkauli.com/about/2024OctFWBK/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;


### PR DESCRIPTION
## Summary
- add `<meta property="og:image" ...>` tags to all about subfolder index pages

## Testing
- `grep -n "og:image" about/*/index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_686ebb8553e48328ad08f428dad3d567