### PR TITLE
Add gallery background preloading and caching

### DIFF
--- a/404.html
+++ b/404.html
@@ -593,5 +593,7 @@ document.getElementById('hamburger').addEventListener('click', function() {
 <div style="font-size: 3.8vw; font-family: Arial Black, Arial, sans-serif; margin: 1vw 0 0 0;">PAGE NOT FOUND</div>
 </div>
 </div>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2020EastRiverTitans/index.html
+++ b/about/2020EastRiverTitans/index.html
@@ -802,5 +802,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2021Backgrounds/index.html
+++ b/about/2021Backgrounds/index.html
@@ -805,5 +805,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2023AprFWBK/index.html
+++ b/about/2023AprFWBK/index.html
@@ -741,5 +741,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2023AprZeus/index.html
+++ b/about/2023AprZeus/index.html
@@ -741,5 +741,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2023AugJapanVillage/index.html
+++ b/about/2023AugJapanVillage/index.html
@@ -741,5 +741,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2023DecParkMart/index.html
+++ b/about/2023DecParkMart/index.html
@@ -741,5 +741,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2023OctFWBK/index.html
+++ b/about/2023OctFWBK/index.html
@@ -741,5 +741,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2023SepTosh/index.html
+++ b/about/2023SepTosh/index.html
@@ -741,5 +741,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2024FebFWBKLondon/index.html
+++ b/about/2024FebFWBKLondon/index.html
@@ -741,5 +741,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2024FebFWBKParis/index.html
+++ b/about/2024FebFWBKParis/index.html
@@ -741,5 +741,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2024NovRunway27/index.html
+++ b/about/2024NovRunway27/index.html
@@ -745,5 +745,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/2024OctFWBK/index.html
+++ b/about/2024OctFWBK/index.html
@@ -754,5 +754,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/index.html
+++ b/about/index.html
@@ -709,5 +709,7 @@ document.getElementById('hamburger').addEventListener('click', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/about/index1.html
+++ b/about/index1.html
@@ -700,5 +700,7 @@ document.getElementById('hamburger').addEventListener('click', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/assets/js/preloadImages.js
+++ b/assets/js/preloadImages.js
@@ -1,0 +1,380 @@
+(function () {
+  'use strict';
+
+  const MAX_CONCURRENCY = 3;
+  const PREFETCH_AHEAD = 2;
+  const COMPLETED = new Set();
+  const IN_FLIGHT = new Set();
+  const QUEUE = [];
+  const PREFETCH_LINKS = new Map();
+  const ATTEMPTS = new Map();
+  let scheduled = false;
+  let activeCount = 0;
+  const isDev = /localhost|127\.0\.0\.1/.test(location.hostname);
+  const startTime = performance.now();
+
+  // Galleries can opt out via data-preload-off on the container.
+
+  function absoluteUrl(url) {
+    try {
+      return new URL(url, document.baseURI).href;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function parseSrcset(srcset) {
+    if (!srcset) return [];
+    return srcset
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const spaceIndex = part.lastIndexOf(' ');
+        if (spaceIndex === -1) {
+          return { url: part, density: null, width: null };
+        }
+        const url = part.slice(0, spaceIndex);
+        const descriptor = part.slice(spaceIndex + 1).trim();
+        if (descriptor.endsWith('x')) {
+          return {
+            url,
+            density: parseFloat(descriptor.replace('x', '')) || 1,
+            width: null,
+          };
+        }
+        if (descriptor.endsWith('w')) {
+          return {
+            url,
+            density: null,
+            width: parseInt(descriptor.replace('w', ''), 10) || null,
+          };
+        }
+        return { url: part, density: null, width: null };
+      });
+  }
+
+  function chooseCandidate(candidates) {
+    if (!candidates.length) return null;
+    const dpr = window.devicePixelRatio || 1;
+    const densityCandidates = candidates
+      .filter((c) => typeof c.density === 'number')
+      .sort((a, b) => a.density - b.density);
+    if (densityCandidates.length) {
+      for (let i = 0; i < densityCandidates.length; i += 1) {
+        if (densityCandidates[i].density >= dpr) {
+          return densityCandidates[i].url;
+        }
+      }
+      return densityCandidates[densityCandidates.length - 1].url;
+    }
+
+    const widthCandidates = candidates
+      .filter((c) => typeof c.width === 'number')
+      .sort((a, b) => a.width - b.width);
+    if (widthCandidates.length) {
+      const target = (window.innerWidth || screen.width || widthCandidates[widthCandidates.length - 1].width || 0) * dpr;
+      for (let i = 0; i < widthCandidates.length; i += 1) {
+        if (widthCandidates[i].width >= target) {
+          return widthCandidates[i].url;
+        }
+      }
+      return widthCandidates[widthCandidates.length - 1].url;
+    }
+
+    return candidates[0].url;
+  }
+
+  function getUrlFromImg(img) {
+    if (!img) return null;
+    const dataSrc = img.getAttribute('data-src') || img.dataset.src;
+    const dataSrcset = img.getAttribute('data-srcset') || img.dataset.srcset;
+    if (dataSrcset) {
+      const choice = chooseCandidate(parseSrcset(dataSrcset));
+      if (choice) return choice;
+    }
+    if (dataSrc) return dataSrc;
+    if (img.currentSrc) return img.currentSrc;
+    return img.getAttribute('src') || null;
+  }
+
+  function sourceIsMatch(source) {
+    const media = source.media;
+    if (media && typeof window.matchMedia === 'function') {
+      try {
+        if (!window.matchMedia(media).matches) {
+          return false;
+        }
+      } catch (err) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function getUrlFromPicture(picture) {
+    const sources = Array.from(picture.querySelectorAll('source')).filter(sourceIsMatch);
+    for (let i = 0; i < sources.length; i += 1) {
+      const source = sources[i];
+      const choice = chooseCandidate(parseSrcset(source.srcset || source.getAttribute('data-srcset') || ''));
+      if (choice) {
+        return choice;
+      }
+    }
+    return getUrlFromImg(picture.querySelector('img'));
+  }
+
+  function collectFromAttribute(value, urls, seen) {
+    if (!value) return;
+    value
+      .split(/[,\s]+/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .forEach((raw) => {
+        const url = absoluteUrl(raw);
+        if (url && !seen.has(url)) {
+          seen.add(url);
+          urls.push(url);
+        }
+      });
+  }
+
+  function getGalleryImageUrls(root) {
+    const urls = [];
+    const seen = new Set();
+
+    if (!root || root.hasAttribute('data-preload-off') || root.dataset.preloadOff === 'true') {
+      return urls;
+    }
+
+    collectFromAttribute(root.getAttribute('data-images') || root.dataset.images, urls, seen);
+    collectFromAttribute(root.getAttribute('data-src-list') || root.dataset.srcList, urls, seen);
+
+    const elements = [];
+    if (root.matches('picture, img')) {
+      elements.push(root);
+    }
+    elements.push.apply(elements, root.querySelectorAll('picture, img'));
+
+    for (let i = 0; i < elements.length; i += 1) {
+      const el = elements[i];
+      if (el.tagName === 'PICTURE') {
+        const url = absoluteUrl(getUrlFromPicture(el));
+        if (url && !seen.has(url)) {
+          seen.add(url);
+          urls.push(url);
+        }
+        continue;
+      }
+      if (el.tagName === 'IMG' && el.parentElement && el.parentElement.tagName === 'PICTURE') {
+        continue;
+      }
+      const imgUrl = absoluteUrl(getUrlFromImg(el));
+      if (imgUrl && !seen.has(imgUrl)) {
+        seen.add(imgUrl);
+        urls.push(imgUrl);
+      }
+    }
+
+    return urls;
+  }
+
+  function removePrefetchLink(url) {
+    const link = PREFETCH_LINKS.get(url);
+    if (link) {
+      link.remove();
+      PREFETCH_LINKS.delete(url);
+    }
+  }
+
+  function updatePrefetchLinks() {
+    if (!document.head) return;
+    const needed = [];
+    for (let i = 0; i < QUEUE.length && needed.length < PREFETCH_AHEAD; i += 1) {
+      const url = QUEUE[i];
+      if (COMPLETED.has(url) || IN_FLIGHT.has(url)) {
+        continue;
+      }
+      needed.push(url);
+    }
+
+    needed.forEach((url) => {
+      if (!PREFETCH_LINKS.has(url)) {
+        const link = document.createElement('link');
+        link.rel = 'prefetch';
+        link.href = url;
+        link.as = 'image';
+        document.head.appendChild(link);
+        PREFETCH_LINKS.set(url, link);
+      }
+    });
+
+    Array.from(PREFETCH_LINKS.keys()).forEach((url) => {
+      if (!needed.includes(url)) {
+        removePrefetchLink(url);
+      }
+    });
+  }
+
+  function scheduleQueue() {
+    if (scheduled) return;
+    scheduled = true;
+    const runner = () => {
+      scheduled = false;
+      runQueue();
+    };
+    if (typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(runner, { timeout: 500 });
+    } else {
+      setTimeout(runner, 0);
+    }
+  }
+
+  function markComplete(url) {
+    IN_FLIGHT.delete(url);
+    COMPLETED.add(url);
+    ATTEMPTS.delete(url);
+    activeCount = Math.max(0, activeCount - 1);
+    removePrefetchLink(url);
+    updatePrefetchLinks();
+    scheduleQueue();
+  }
+
+  function runQueue() {
+    updatePrefetchLinks();
+    while (activeCount < MAX_CONCURRENCY && QUEUE.length) {
+      const url = QUEUE.shift();
+      if (!url || COMPLETED.has(url) || IN_FLIGHT.has(url)) {
+        continue;
+      }
+      IN_FLIGHT.add(url);
+      if (!ATTEMPTS.has(url)) {
+        ATTEMPTS.set(url, 0);
+      }
+      activeCount += 1;
+      warmUrl(url);
+    }
+  }
+
+  function trackFailure(url, attempt, err) {
+    if (isDev) {
+      console.warn('[gallery-preload] Failed', url, 'attempt', attempt + 1, err);
+    }
+    IN_FLIGHT.delete(url);
+    activeCount = Math.max(0, activeCount - 1);
+    if (attempt < 1) {
+      ATTEMPTS.set(url, attempt + 1);
+      QUEUE.push(url);
+    } else {
+      removePrefetchLink(url);
+      COMPLETED.add(url);
+      ATTEMPTS.delete(url);
+    }
+    scheduleQueue();
+  }
+
+  function loadImage(url) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('Image failed'));
+      img.src = url;
+    });
+  }
+
+  function fetchImage(url) {
+    return fetch(url, { cache: 'force-cache', mode: 'no-cors' });
+  }
+
+  function warmUrl(url) {
+    const attempt = ATTEMPTS.get(url) || 0;
+    Promise.all([loadImage(url), fetchImage(url)])
+      .then(() => {
+        markComplete(url);
+      })
+      .catch((err) => {
+        trackFailure(url, attempt, err);
+      });
+  }
+
+  function enqueue(url) {
+    if (!url || COMPLETED.has(url) || IN_FLIGHT.has(url)) {
+      return;
+    }
+    if (!QUEUE.includes(url)) {
+      QUEUE.push(url);
+      if (!ATTEMPTS.has(url)) {
+        ATTEMPTS.set(url, 0);
+      }
+    }
+  }
+
+  function enqueueAll(urls) {
+    urls.forEach(enqueue);
+    scheduleQueue();
+  }
+
+  function init() {
+    const loadedImages = document.querySelectorAll('img');
+    for (let i = 0; i < loadedImages.length; i += 1) {
+      const img = loadedImages[i];
+      if (img.complete) {
+        const url = absoluteUrl(img.currentSrc || img.src || img.getAttribute('data-src'));
+        if (url) {
+          COMPLETED.add(url);
+        }
+      }
+    }
+
+    const galleries = new Set();
+    const selectors = ['[data-gallery]', '.gallery', '.slides', '[data-images]', '[data-src-list]'];
+    for (let i = 0; i < selectors.length; i += 1) {
+      const found = document.querySelectorAll(selectors[i]);
+      for (let j = 0; j < found.length; j += 1) {
+        galleries.add(found[j]);
+      }
+    }
+
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {});
+    }
+
+    if (!galleries.size) {
+      if (isDev) {
+        console.info('[gallery-preload] No galleries found');
+      }
+      return;
+    }
+
+    galleries.forEach((gallery) => {
+      const urls = getGalleryImageUrls(gallery);
+      enqueueAll(urls);
+    });
+
+    if (QUEUE.length && isDev) {
+      console.info('[gallery-preload] Queued', QUEUE.length, 'images in', Math.round(performance.now() - startTime), 'ms');
+    }
+
+    scheduleQueue();
+
+    if (isDev) {
+      const logCompletion = () => {
+        if (IN_FLIGHT.size === 0 && QUEUE.length === 0) {
+          console.info('[gallery-preload] Completed in', Math.round(performance.now() - startTime), 'ms');
+        } else {
+          requestAnimationFrame(logCompletion);
+        }
+      };
+      requestAnimationFrame(logCompletion);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+
+  // Export helper for debugging if needed.
+  window.__rkPreload = { getGalleryImageUrls };
+})();

--- a/contact/index.html
+++ b/contact/index.html
@@ -738,5 +738,7 @@ document.querySelector('.contact-form').addEventListener('submit', function(e) {
 });
 </script>
 
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -209,5 +209,7 @@ model-viewer {
       viewer.setAttribute('camera-orbit', '215deg 90deg 110%');
     }
   </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/me/index.html
+++ b/me/index.html
@@ -628,5 +628,7 @@ body.menu-open .hamburger span:nth-child(3) {
 document.getElementById('hamburger').addEventListener('click', function() {
   document.body.classList.toggle('menu-open');
 });
-</script></body>
+</script>
+<script src="/assets/js/preloadImages.js" defer></script>
+</body>
 </html>

--- a/portfolio/ArsenalPants/index.html
+++ b/portfolio/ArsenalPants/index.html
@@ -780,5 +780,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/BrainBucketHat/index.html
+++ b/portfolio/BrainBucketHat/index.html
@@ -780,5 +780,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/CensoredGlasses/index.html
+++ b/portfolio/CensoredGlasses/index.html
@@ -794,5 +794,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/CensoredShirt/index.html
+++ b/portfolio/CensoredShirt/index.html
@@ -786,5 +786,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/ClearPocketPants2/index.html
+++ b/portfolio/ClearPocketPants2/index.html
@@ -789,5 +789,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/EyeSeeYouButtonUp/index.html
+++ b/portfolio/EyeSeeYouButtonUp/index.html
@@ -787,5 +787,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/FireFighterHat/index.html
+++ b/portfolio/FireFighterHat/index.html
@@ -794,5 +794,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/FlowerVision/index.html
+++ b/portfolio/FlowerVision/index.html
@@ -787,5 +787,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/GalaxyHoodie/index.html
+++ b/portfolio/GalaxyHoodie/index.html
@@ -797,5 +797,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/GalaxyPants/index.html
+++ b/portfolio/GalaxyPants/index.html
@@ -792,5 +792,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/JetpackBackPack/index.html
+++ b/portfolio/JetpackBackPack/index.html
@@ -792,5 +792,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/LockedUpDress/index.html
+++ b/portfolio/LockedUpDress/index.html
@@ -792,5 +792,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/MattressBackpack/index.html
+++ b/portfolio/MattressBackpack/index.html
@@ -798,5 +798,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/MillionDollarBackpack/index.html
+++ b/portfolio/MillionDollarBackpack/index.html
@@ -787,5 +787,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/MoneyDuffelBag/index.html
+++ b/portfolio/MoneyDuffelBag/index.html
@@ -788,5 +788,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/MoneySuit/index.html
+++ b/portfolio/MoneySuit/index.html
@@ -792,5 +792,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/NudeScarf/index.html
+++ b/portfolio/NudeScarf/index.html
@@ -788,5 +788,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/OneWayHat/index.html
+++ b/portfolio/OneWayHat/index.html
@@ -788,5 +788,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/SleepySet/index.html
+++ b/portfolio/SleepySet/index.html
@@ -800,5 +800,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/StopSignBackpack/index.html
+++ b/portfolio/StopSignBackpack/index.html
@@ -787,5 +787,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/StopSignMiniBag/index.html
+++ b/portfolio/StopSignMiniBag/index.html
@@ -788,5 +788,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/TVBackpack/index.html
+++ b/portfolio/TVBackpack/index.html
@@ -780,5 +780,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/TeddyHat/index.html
+++ b/portfolio/TeddyHat/index.html
@@ -787,5 +787,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/TeddySet/index.html
+++ b/portfolio/TeddySet/index.html
@@ -794,5 +794,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/TeddySweater/index.html
+++ b/portfolio/TeddySweater/index.html
@@ -788,5 +788,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -829,5 +829,7 @@ document.getElementById('hamburger').addEventListener('click', function() {
   }, { passive: true });
 });
 </script>
+
+<script src="/assets/js/preloadImages.js" defer></script>
 </body>
 </html>

--- a/portfolio/previousindex.html
+++ b/portfolio/previousindex.html
@@ -698,5 +698,7 @@ body::-webkit-scrollbar {
 document.getElementById('hamburger').addEventListener('click', function() {
   document.body.classList.toggle('menu-open');
 });
-</script></body>
+</script>
+<script src="/assets/js/preloadImages.js" defer></script>
+</body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,51 @@
+const CACHE_NAME = 'rk-gallery-v1';
+const CACHE_PREFIX = 'rk-gallery-';
+const IMAGE_PATTERN = /\.(?:jpe?g|png|webp|avif)(?:\?.*)?$/i;
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheNames = await caches.keys();
+      await Promise.all(
+        cacheNames
+          .filter((name) => name.startsWith(CACHE_PREFIX) && name !== CACHE_NAME)
+          .map((name) => caches.delete(name))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+  const url = new URL(request.url);
+  if (!IMAGE_PATTERN.test(url.pathname)) {
+    return;
+  }
+
+  event.respondWith(staleWhileRevalidate(request));
+});
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+  try {
+    const response = await fetch(request);
+    if (response && (response.ok || response.type === 'opaque')) {
+      cache.put(request, response.clone());
+    }
+    return cached || response;
+  } catch (err) {
+    if (cached) {
+      return cached;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add a preloadImages module that discovers gallery images, warms caches with a throttled queue, and exposes a data-preload-off escape hatch
- add a lightweight service worker to cache gallery image responses with stale-while-revalidate
- include the preload script on every HTML page so background fetching starts automatically after DOMContentLoaded

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d98abb2f0883288de96cd65bc82536