### PR TITLE
Apply case-sensitive whole-word replacements: `portfolio`→`clothes`, `archive`→`portfolio`

### DIFF
--- a/404.html
+++ b/404.html
@@ -554,18 +554,18 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
+/* Highlight active Clothes menu item in mobile overlay */
 
 
 
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes button in desktop nav */
 
 </style>
 </head>
 <body>
 <div class="product-grid">
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='https://richardkauli.com/portfolio'">PORTFOLIO</button><button onclick="location.href='https://richardkauli.com/archive/'">ARCHIVE</button><button onclick="location.href='https://richardkauli.com/contact'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='https://richardkauli.com/clothes'">CLOTHES</button><button onclick="location.href='https://richardkauli.com/portfolio/'">PORTFOLIO</button><button onclick="location.href='https://richardkauli.com/contact'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -575,8 +575,8 @@ body.menu-open .hamburger span:nth-child(3) {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com">HOME</a></li>
-<li><a href="https://www.richardkauli.com/portfolio">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/clothes">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/about/index.html
+++ b/about/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta http-equiv="refresh" content="0; url=https://www.richardkauli.com/archive/" />
-  <link rel="canonical" href="https://www.richardkauli.com/archive/" />
-  <title>Redirecting to Archive</title>
+  <meta http-equiv="refresh" content="0; url=https://www.richardkauli.com/portfolio/" />
+  <link rel="canonical" href="https://www.richardkauli.com/portfolio/" />
+  <title>Redirecting to Portfolio</title>
 </head>
 <body>
-  <p>This page has moved to <a href="https://www.richardkauli.com/archive/">Archive</a>.</p>
+  <p>This page has moved to <a href="https://www.richardkauli.com/portfolio/">Portfolio</a>.</p>
 </body>
 </html>

--- a/archive/2020EastRiverTitans/index.html
+++ b/archive/2020EastRiverTitans/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>East River Titans</title>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2020EastRiverTitans/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2020EastRiverTitans/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -741,8 +741,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -754,8 +754,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2021Backgrounds/index.html
+++ b/archive/2021Backgrounds/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Backgrounds</title>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2021Backgrounds/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2021Backgrounds/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -757,8 +757,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023AprFWBK/index.html
+++ b/archive/2023AprFWBK/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Apr Fashion Week Brooklyn - CENSORED SS23 Collection, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2023AprFWBK/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2023AprFWBK/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023AprZeus/index.html
+++ b/archive/2023AprZeus/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Apr ZEUS - CENSORED SS23 Collection, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2023AprZeus/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2023AprZeus/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023AugJapanVillage/index.html
+++ b/archive/2023AugJapanVillage/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Aug Japan Village - Million Dollar Bag Debut, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2023AugJapanVillage/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2023AugJapanVillage/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023DecParkMart/index.html
+++ b/archive/2023DecParkMart/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Dec ParkMart - Fashion Pop-Up, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2023DecParkMart/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2023DecParkMart/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023OctFWBK/index.html
+++ b/archive/2023OctFWBK/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Oct Fashion Week Brooklyn - POWER NAP Collection, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2023OctFWBK/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2023OctFWBK/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023SepTosh/index.html
+++ b/archive/2023SepTosh/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2023 Sep TOSH - CASH ME IF YOU CAN Collection, New York, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2023SepTosh/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2023SepTosh/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2024FebFWBKLondon/index.html
+++ b/archive/2024FebFWBKLondon/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2024 Feb Fashion Week Brooklyn - POWER NAP Collection, London, United Kingdom</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2024FebFWBKLondon/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2024FebFWBKLondon/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2024FebFWBKParis/index.html
+++ b/archive/2024FebFWBKParis/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2024 Feb Fashion Week Brooklyn - POWER NAP Collection, Paris, France</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2024FebFWBKParis/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2024FebFWBKParis/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2024NovRunway27/index.html
+++ b/archive/2024NovRunway27/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2024 Nov Runway 27 - TV Backpack, Fashion Institute of Technology, New York, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2024NovRunway27/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2024NovRunway27/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -685,8 +685,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -697,8 +697,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2024OctFWBK/index.html
+++ b/archive/2024OctFWBK/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>2024 Oct Fashion Week Brooklyn - PLUGGED IN TOO Collection, Brooklyn, NY</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2024OctFWBK/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2024OctFWBK/1.jpg" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -694,8 +694,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -706,8 +706,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025AprFlier/index.html
+++ b/archive/2025AprFlier/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>#2</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2025AprFlier/1.mp4" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2025AprFlier/1.mp4" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -690,8 +690,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -702,8 +702,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025AugFlier/index.html
+++ b/archive/2025AugFlier/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>22nd Birthday</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2025AugFlier/1.mp4" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2025AugFlier/1.mp4" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -690,8 +690,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -702,8 +702,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025DecFlier/index.html
+++ b/archive/2025DecFlier/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>Real Ones Pt 6</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2025AugFlier/1.mp4" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2025AugFlier/1.mp4" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -690,8 +690,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -702,8 +702,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025JulFlier/index.html
+++ b/archive/2025JulFlier/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>The Fourth Gathering</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2025JulFlier/1.mp4" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2025JulFlier/1.mp4" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -691,8 +691,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -703,8 +703,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025MarFlier/index.html
+++ b/archive/2025MarFlier/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Housewarming</title>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2025MarFlier/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2025MarFlier/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -720,8 +720,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -733,8 +733,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025MayFlier/index.html
+++ b/archive/2025MayFlier/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8"/>
 <title>BBQ at Prospect</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<meta property="og:image" content="https://www.richardkauli.com/archive/2025MayFlier/1.mp4" />
+<meta property="og:image" content="https://www.richardkauli.com/portfolio/2025MayFlier/1.mp4" />
 <style>
 .bottom-nav button {
   font-family: 'ArialBlackCustom', Arial Black, Arial, sans-serif;
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -690,8 +690,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -702,8 +702,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/index.html
+++ b/archive/index.html
@@ -13,7 +13,7 @@
 <link href="https://www.richardkauli.com/favicon.png" rel="icon" type="image/png"/>
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
-<title>Richard Kauli - Archive</title>
+<title>Richard Kauli - Portfolio</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 @font-face {
@@ -562,14 +562,14 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-.mobile-menu-overlay a[href*="archive"] {
+/* Highlight active Clothes menu item in mobile overlay */
+.mobile-menu-overlay a[href*="portfolio"] {
   color: red !important;
 }
 
 
-/* Highlight active Portfolio button in desktop nav */
-.bottom-nav button[onclick*="archive"] {
+/* Highlight active Clothes button in desktop nav */
+.bottom-nav button[onclick*="portfolio"] {
   color: red !important;
 }
 
@@ -632,10 +632,10 @@ a.project-link img {
 a.project-link:hover img {
   filter: brightness(0) invert(1);
 }
-</style><link rel="canonical" href="https://www.richardkauli.com/archive/" />
-<meta property="og:title" content="ARCHIVE | Richard Kauli" />
-<meta property="og:url" content="https://www.richardkauli.com/archive/" />
-<meta name="twitter:title" content="ARCHIVE | Richard Kauli" />
+</style><link rel="canonical" href="https://www.richardkauli.com/portfolio/" />
+<meta property="og:title" content="PORTFOLIO | Richard Kauli" />
+<meta property="og:url" content="https://www.richardkauli.com/portfolio/" />
+<meta name="twitter:title" content="PORTFOLIO | Richard Kauli" />
 </head>
 <body style="margin-top: 0; padding-top: 0;">
 <div class="about-structured" style="max-width: 1000px; margin: 0 auto 12em auto; padding: 0 5vw; font-family: Courier, monospace; font-size: 1em; line-height: 1.6;">
@@ -643,33 +643,33 @@ a.project-link:hover img {
 <a class="project-link" href="https://2022-artshow.freeinquotes.com/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_blank">2022 Jul SEE HOW FREE YOU REALLY ARE - Fashion and Web3 Pop-Up, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2022 Nov Piece Unik - Fashion Experience and Auction, Los Angeles, CA</span>
 <a class="project-link" href="https://www.youtube.com/watch?v=ADoRabr_ZRU" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_blank">2023 Nov UNDER TRACKS_ - Short film, Osaka, Japan<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2023DecParkMart/" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2023 Dec ParkMart - Fashion Pop-Up, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2023DecParkMart/" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2023 Dec ParkMart - Fashion Pop-Up, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2024 Sep Piece Unik - Fashion Experience and Auction, New York, NY</span>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2025 Aug Slow Driving Club - Motorcycle Enthusiast Club, New York, NY</span>
 <div style="margin-top:1em;"></div><strong>Selected Fashion Shows:</strong><div style="margin-bottom:1em;"></div>
-<a class="project-link" href="/archive/2023AprZeus/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Apr ZEUS - CENSORED SS23 Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2023AprFWBK/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Apr Fashion Week Brooklyn - CENSORED SS23 Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2023AprZeus/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Apr ZEUS - CENSORED SS23 Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2023AprFWBK/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Apr Fashion Week Brooklyn - CENSORED SS23 Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2023 Apr ZEUS - CENSORED SS23 Collection, Brooklyn, NY</span>
-<a class="project-link" href="/archive/2023AugJapanVillage/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Aug Japan Village - Million Dollar Bag Debut, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2023SepTosh/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Sep TOSH - CASH ME IF YOU CAN, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2023OctFWBK/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Oct Fashion Week Brooklyn - POWER NAP Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2024FebFWBKLondon/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Feb Fashion Week Brooklyn - POWER NAP Collection, London, United Kingdom<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2023AugJapanVillage/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Aug Japan Village - Million Dollar Bag Debut, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2023SepTosh/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Sep TOSH - CASH ME IF YOU CAN, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2023OctFWBK/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Oct Fashion Week Brooklyn - POWER NAP Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2024FebFWBKLondon/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Feb Fashion Week Brooklyn - POWER NAP Collection, London, United Kingdom<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2024 Feb Fashion Week Brooklyn - POWER NAP Collection, Paris, France</span>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2024 Apr Fashion Week Brooklyn - PLUGGED IN Collection, Brooklyn, NY</span>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Oct Fashion Week Brooklyn - PLUGGED IN TOO Collection, Brooklyn, NY</span>
-<a class="project-link" href="/archive/2024NovRunway27/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Nov Runway 27 - TV Backpack, Fashion Institute of Technology, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2024NovRunway27/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Nov Runway 27 - TV Backpack, Fashion Institute of Technology, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <p><strong>Books/Zines:</strong>
-<a class="project-link" href="/archive/2020EastRiverTitans/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2020 Apr East River Titans, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2021Backgrounds/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2021 Mar Backgrounds, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2020EastRiverTitans/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2020 Apr East River Titans, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2021Backgrounds/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2021 Mar Backgrounds, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 </p>
 
 <p><strong>Event Fliers:</strong>
-<a class="project-link" href="/archive/2025MarFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Mar Housewarming, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2025AprFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Apr #2, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2025MayFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 May Prospect Park BBQ, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2025JulFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Jul The Fourth Gathering, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2025MarFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Mar Housewarming, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2025AprFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Apr #2, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2025MayFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 May Prospect Park BBQ, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2025JulFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Jul The Fourth Gathering, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2025 Aug 22nd Birthday, Brooklyn, NY</span>
-<a class="project-link" href="/archive/2025DecFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Dec Real Ones Pt 6, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link" href="/portfolio/2025DecFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Dec Real Ones Pt 6, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 </p>
 
 <p><strong>Brands:</strong>
@@ -691,7 +691,7 @@ a.project-link:hover img {
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2023 - 2025 Fashion Business Management AAS, Fashion Institute of Technology, New York, NY</span>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2025 - 2026 Advertising and Marketing Communications BS, Fashion Institute of Technology, New York, NY</span>
 </p></p></div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../clothes/'">CLOTHES</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -700,8 +700,8 @@ a.project-link:hover img {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../clothes/">CLOTHES</a></li>
+<li><a href="../portfolio/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/contact/index.html
+++ b/contact/index.html
@@ -554,13 +554,13 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
+/* Highlight active Clothes menu item in mobile overlay */
 .mobile-menu-overlay a[href*="contact"] {
   color: red !important;
 }
 
 
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes button in desktop nav */
 .bottom-nav button[onclick*="contact"] {
   color: red !important;
 }
@@ -699,7 +699,7 @@ body.menu-open .hamburger span:nth-child(3) {
     <button type="submit">Send</button>
   </form>
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../clothes/'">CLOTHES</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -708,8 +708,8 @@ body.menu-open .hamburger span:nth-child(3) {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../clothes/">CLOTHES</a></li>
+<li><a href="../portfolio/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@ model-viewer {
 </model-viewer>
 </div>
 <div class="button-panel">
+<a href="clothes/" style="text-decoration: none; color: inherit;"><div>CLOTHES</div></a>
 <a href="portfolio/" style="text-decoration: none; color: inherit;"><div>PORTFOLIO</div></a>
-<a href="archive/" style="text-decoration: none; color: inherit;"><div>ARCHIVE</div></a>
 <a href="contact/" style="text-decoration: none; color: inherit;"><div>CONTACT</div></a>
 </div>
 </div>

--- a/me/index.html
+++ b/me/index.html
@@ -5,7 +5,7 @@
 <head><link href="https://www.richardkauli.com/favicon.png" rel="icon" type="image/png"/>
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
-<title>Richard Kauli - Portfolio</title>
+<title>Richard Kauli - Clothes</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 @font-face {
@@ -554,13 +554,13 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
+/* Highlight active Clothes menu item in mobile overlay */
 .mobile-menu-overlay a[href*="index"] {
   color: red !important;
 }
 
 
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes button in desktop nav */
 
 
 .bottom-nav button[onclick="location.href='https://www.richardkauli.com'"] {
@@ -609,7 +609,7 @@ body.menu-open .hamburger span:nth-child(3) {
 
 </div>
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../clothes/'">CLOTHES</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -618,8 +618,8 @@ body.menu-open .hamburger span:nth-child(3) {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="../index.html">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="../index.html">RICHARD KAULI</a></li><li><a href="../clothes/">CLOTHES</a></li>
+<li><a href="../portfolio/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/ArsenalPants/index.html
+++ b/portfolio/ArsenalPants/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Arsenal Pants</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/ArsenalPants/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/ArsenalPants/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -719,8 +719,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/BirdBeanie/index.html
+++ b/portfolio/BirdBeanie/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Doves Can Fly</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/BirdBeanie/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/BirdBeanie/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/BirdBelt/index.html
+++ b/portfolio/BirdBelt/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Dove Belt</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/BirdBelt/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/BirdBelt/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -723,8 +723,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -736,8 +736,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/BrainBucketHat/index.html
+++ b/portfolio/BrainBucketHat/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Brain Bucket Hat</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/BrainBucketHat/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/BrainBucketHat/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -719,8 +719,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li
-  ><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+  ><li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/CensoredGlasses/index.html
+++ b/portfolio/CensoredGlasses/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Censored Glasses</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/CensoredGlasses/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/CensoredGlasses/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -733,8 +733,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -746,8 +746,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/CensoredShirt/index.html
+++ b/portfolio/CensoredShirt/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Censored Shirt</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/CensoredShirt/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/CensoredShirt/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -725,8 +725,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -738,8 +738,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/ClearPocketPants2/index.html
+++ b/portfolio/ClearPocketPants2/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Clear Pocket Pants V.2</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/ClearPocketPants2/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/ClearPocketPants2/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -728,8 +728,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -741,8 +741,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/EyeSeeYouButtonUp/index.html
+++ b/portfolio/EyeSeeYouButtonUp/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Eye See You Button Up</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/EyeSeeYouButtonUp/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/EyeSeeYouButtonUp/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/FireFighterHat/index.html
+++ b/portfolio/FireFighterHat/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>FireFighter Hat</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/FireFighterHat/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/FireFighterHat/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -733,8 +733,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -746,8 +746,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/FlowerVision/index.html
+++ b/portfolio/FlowerVision/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Flower Vision Glasses</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/FlowerVision/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/FlowerVision/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/GalaxyHoodie/index.html
+++ b/portfolio/GalaxyHoodie/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Galaxy Hoodie</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/GalaxyHoodie/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/GalaxyHoodie/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -736,8 +736,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -749,8 +749,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/GalaxyPants/index.html
+++ b/portfolio/GalaxyPants/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Gallaxy Pants</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/GalaxyPants/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/GalaxyPants/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -731,8 +731,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/JetpackBackPack/index.html
+++ b/portfolio/JetpackBackPack/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Jetpack BackPack</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/JetpackBackPack/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/JetpackBackPack/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -731,8 +731,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/KidsuperTee/index.html
+++ b/portfolio/KidsuperTee/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>KDSPR Tee</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/KidSuperTee/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/KidSuperTee/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -745,8 +745,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/LockedUpDress/index.html
+++ b/portfolio/LockedUpDress/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Locked Up Dress</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/LockedUpDress/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/LockedUpDress/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -731,8 +731,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/MattressBackpack/index.html
+++ b/portfolio/MattressBackpack/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Mattress Backpack</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/MattressBackpack/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/MattressBackpack/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -737,8 +737,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -750,8 +750,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/MillionDollarBackpack/index.html
+++ b/portfolio/MillionDollarBackpack/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Million Dollar Backpack</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/MillionDollarBackpack/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/MillionDollarBackpack/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/MoneyDuffelBag/index.html
+++ b/portfolio/MoneyDuffelBag/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Million Dollar Duffel</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/MoneyDuffelBag/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/MoneyDuffelBag/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/MoneySuit/index.html
+++ b/portfolio/MoneySuit/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Million Dollar Suit</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/MoneySuit/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/MoneySuit/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -731,8 +731,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/NudeScarf/index.html
+++ b/portfolio/NudeScarf/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Nude Scarf</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/NudeScarf/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/NudeScarf/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/OneWayHat/index.html
+++ b/portfolio/OneWayHat/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>One Way Hat</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/OneWayHat/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/OneWayHat/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/RunningSweater/index.html
+++ b/portfolio/RunningSweater/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Running Hoodie</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/RunningSweater/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/RunningSweater/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -745,8 +745,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/RunningSweatpants/index.html
+++ b/portfolio/RunningSweatpants/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Running Pants</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/RunningSweatpants/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/RunningSweatpants/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/SleepySet/index.html
+++ b/portfolio/SleepySet/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Sleepy Set</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/SleepySet/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/SleepySet/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -752,8 +752,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/StopSignBackpack/index.html
+++ b/portfolio/StopSignBackpack/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Stop Sign Backpack</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/StopSignBackpack/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/StopSignBackpack/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/StopSignMiniBag/index.html
+++ b/portfolio/StopSignMiniBag/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Stop Sign Mini Bag</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/StopSignMiniBag/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/StopSignMiniBag/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/TVBackpack/index.html
+++ b/portfolio/TVBackpack/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>TV Backpack</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/TVBackpack/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/TVBackpack/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -719,8 +719,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/TeddyHat/index.html
+++ b/portfolio/TeddyHat/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Teddy Hat</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/TeddyHat/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/TeddyHat/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/TeddySet/index.html
+++ b/portfolio/TeddySet/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Teddy Set</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/TeddySet/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/TeddySet/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -733,8 +733,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -746,8 +746,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/TeddySweater/index.html
+++ b/portfolio/TeddySweater/index.html
@@ -6,7 +6,7 @@
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
 <title>Teddy Sweater</title>
-<meta property="og:image" content="https://www.richardkauli.com/portfolio/TeddySweater/1.jpg" />
+<meta property="og:image" content="https://www.richardkauli.com/clothes/TeddySweater/1.jpg" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 .bottom-nav button {
@@ -559,8 +559,8 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-/* Highlight active Portfolio button in desktop nav */
+/* Highlight active Clothes menu item in mobile overlay */
+/* Highlight active Clothes button in desktop nav */
 /* ToggleModel underline hover and hitbox */
 #toggleModel {
   display: block;
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
+<button onclick="location.href='https://www.richardkauli.com/clothes/'">CLOTHES</button>
 <button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
+<li><a href="https://www.richardkauli.com/clothes/">CLOTHES</a></li>
 <li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -13,7 +13,7 @@
 <link href="https://www.richardkauli.com/favicon.png" rel="icon" type="image/png"/>
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
-<title>Richard Kauli - Portfolio</title>
+<title>Richard Kauli - Clothes</title>
 <meta property="og:image" content="https://www.richardkauli.com/HELLO2.glb" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
@@ -576,14 +576,14 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-.mobile-menu-overlay a[href*="portfolio"] {
+/* Highlight active Clothes menu item in mobile overlay */
+.mobile-menu-overlay a[href*="clothes"] {
   color: red !important;
 }
 
 
-/* Highlight active Portfolio button in desktop nav */
-.bottom-nav button[onclick*="portfolio"] {
+/* Highlight active Clothes button in desktop nav */
+.bottom-nav button[onclick*="clothes"] {
   color: red !important;
 }
 
@@ -826,7 +826,7 @@ body::-webkit-scrollbar {
 <div style="height: 1em;"></div>
 </div>
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../clothes/'">CLOTHES</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -835,8 +835,8 @@ body::-webkit-scrollbar {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../clothes/">CLOTHES</a></li>
+<li><a href="../portfolio/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/index_old.html
+++ b/portfolio/index_old.html
@@ -5,7 +5,7 @@
 <head><link href="https://www.richardkauli.com/favicon.png" rel="icon" type="image/png"/>
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
-<title>Richard Kauli - Portfolio</title>
+<title>Richard Kauli - Clothes</title>
 <meta property="og:image" content="https://www.richardkauli.com/HELLO2.glb" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
@@ -568,14 +568,14 @@ body.menu-open .hamburger span:nth-child(3) {
 }
 
 
-/* Highlight active Portfolio menu item in mobile overlay */
-.mobile-menu-overlay a[href*="portfolio"] {
+/* Highlight active Clothes menu item in mobile overlay */
+.mobile-menu-overlay a[href*="clothes"] {
   color: red !important;
 }
 
 
-/* Highlight active Portfolio button in desktop nav */
-.bottom-nav button[onclick*="portfolio"] {
+/* Highlight active Clothes button in desktop nav */
+.bottom-nav button[onclick*="clothes"] {
   color: red !important;
 }
 
@@ -843,7 +843,7 @@ body::-webkit-scrollbar {
 <div style="height: 1em;"></div>
 </div>
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../clothes/'">CLOTHES</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -852,8 +852,8 @@ body::-webkit-scrollbar {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../clothes/">CLOTHES</a></li>
+<li><a href="../portfolio/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/scripts/rename-about-to-archive.mjs
+++ b/scripts/rename-about-to-archive.mjs
@@ -4,9 +4,9 @@ import path from 'path';
 import { execSync } from 'child_process';
 
 const root = process.cwd();
-const archiveUrl = 'https://www.richardkauli.com/archive/';
-const archiveTitle = 'ARCHIVE | Richard Kauli';
-const archivePageRelative = path.join('archive', 'index.html');
+const archiveUrl = 'https://www.richardkauli.com/portfolio/';
+const archiveTitle = 'PORTFOLIO | Richard Kauli';
+const archivePageRelative = path.join('portfolio', 'index.html');
 const targetExtensions = new Set(['.html', '.htm', '.css', '.js', '.json', '.xml', '.md']);
 const changedFiles = new Set();
 
@@ -29,16 +29,16 @@ function recordChange(filePath) {
 
 async function renameFolderIfNeeded() {
   const aboutPath = path.join(root, 'about');
-  const archivePath = path.join(root, 'archive');
+  const archivePath = path.join(root, 'portfolio');
   const aboutExists = await pathExists(aboutPath);
   const archiveExists = await pathExists(archivePath);
 
   if (aboutExists && !archiveExists) {
-    log('Renaming about -> archive using git mv');
+    log('Renaming about -> portfolio using git mv');
     execSync(`git mv "${aboutPath}" "${archivePath}"`, { stdio: 'inherit' });
     recordChange(archivePath);
   } else if (aboutExists && archiveExists) {
-    log('Both about and archive folders exist, skipping rename');
+    log('Both about and portfolio folders exist, skipping rename');
   } else {
     log('No about folder to rename');
   }
@@ -48,9 +48,9 @@ function transformUrlValue(value) {
   let updated = value;
   const original = value;
 
-  updated = updated.replace(/https:\/\/www\.richardkauli\.com\/about\/?/g, 'https://www.richardkauli.com/archive/');
-  updated = updated.replace(/https:\/\/richardkauli\.com\/about\/?/g, 'https://richardkauli.com/archive/');
-  updated = updated.replace(/(^|\/)(about)(?=\/|$|\?)/g, (_, prefix) => `${prefix}archive`);
+  updated = updated.replace(/https:\/\/www\.richardkauli\.com\/about\/?/g, 'https://www.richardkauli.com/portfolio/');
+  updated = updated.replace(/https:\/\/richardkauli\.com\/about\/?/g, 'https://richardkauli.com/portfolio/');
+  updated = updated.replace(/(^|\/)(about)(?=\/|$|\?)/g, (_, prefix) => `${prefix}portfolio`);
 
   return updated === original ? value : updated;
 }
@@ -100,9 +100,9 @@ function updateArchivePage(content) {
   updated = updated.replace(/<title>[^<]*<\/title>/i, `<title>${archiveTitle}</title>`);
 
   if (/<h1[^>]*>/i.test(updated)) {
-    updated = updated.replace(/<h1[^>]*>[^<]*<\/h1>/i, '<h1>Archive</h1>');
+    updated = updated.replace(/<h1[^>]*>[^<]*<\/h1>/i, '<h1>Portfolio</h1>');
   } else {
-    updated = updated.replace(/<body[^>]*>/i, match => `${match}\n<h1>Archive</h1>`);
+    updated = updated.replace(/<body[^>]*>/i, match => `${match}\n<h1>Portfolio</h1>`);
   }
 
   const canonicalTag = `<link rel="canonical" href="${archiveUrl}" />`;
@@ -162,7 +162,7 @@ async function walk(dir) {
 async function ensureRedirect() {
   const redirectDir = path.join(root, 'about');
   const redirectFile = path.join(redirectDir, 'index.html');
-  const redirectHtml = `<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8" />\n  <meta http-equiv="refresh" content="0; url=${archiveUrl}" />\n  <link rel="canonical" href="${archiveUrl}" />\n  <title>Redirecting to Archive</title>\n</head>\n<body>\n  <p>This page has moved to <a href="${archiveUrl}">Archive</a>.</p>\n</body>\n</html>\n`;
+  const redirectHtml = `<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8" />\n  <meta http-equiv="refresh" content="0; url=${archiveUrl}" />\n  <link rel="canonical" href="${archiveUrl}" />\n  <title>Redirecting to Portfolio</title>\n</head>\n<body>\n  <p>This page has moved to <a href="${archiveUrl}">Portfolio</a>.</p>\n</body>\n</html>\n`;
 
   await fs.mkdir(redirectDir, { recursive: true });
   await fs.writeFile(redirectFile, redirectHtml);


### PR DESCRIPTION
### Motivation
- Standardize site wording by renaming visible "portfolio" pages/labels to "clothes" and promoting the previous "archive" name to the public-facing "portfolio" label and URLs.
- Keep all code identifiers, camelCase tokens, and other in-code names intact by using whole-word, case-sensitive replacements.

### Description
- Performed case-sensitive, whole-word replacements across HTML/JS/template-like files so that `portfolio` → `clothes` (and `Portfolio` → `Clothes`, `PORTFOLIO` → `CLOTHES`) and `archive` → `portfolio` (and `Archive` → `Portfolio`, `ARCHIVE` → `PORTFOLIO`).
- Updated link targets, navigation labels, `og:`/canonical meta URLs and `meta` titles where the words appeared as standalone tokens, and adjusted the `about` redirect to point to the new `portfolio` URL.
- Applied the same transformations to the helper script `scripts/rename-about-to-archive.mjs` so its configured URLs and target paths now reference `portfolio`/`clothes` consistently.
- Changes touch site content and templates across the project: 57 files were modified in total with substitutions applied to navigation, meta tags, and per-project pages.

### Testing
- Ran the replacement script (`python` one-liner) across matching extensions which completed successfully and reported the set of modified files and substitution totals. 
- Verified results with pattern searches using `rg` to find remaining occurrences of the target words and to confirm case-sensitive whole-word matches, which returned expected updated references.
- Served the updated site locally with `python -m http.server` and captured a full-page screenshot using Playwright to spot-check the rendered navigation and labels, which succeeded. 
- Confirmed file modifications are staged in the working tree and the repository diff contains the expected per-file updates (files modified: 57).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948e38ecfc8328844d78f2b0902449)