### PR TITLE
Rename Portfolio → Clothes and Archive → Portfolio (labels only)

### DIFF
--- a/404.html
+++ b/404.html
@@ -565,7 +565,7 @@ body.menu-open .hamburger span:nth-child(3) {
 <body>
 <div class="product-grid">
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='https://richardkauli.com/portfolio'">PORTFOLIO</button><button onclick="location.href='https://richardkauli.com/archive/'">ARCHIVE</button><button onclick="location.href='https://richardkauli.com/contact'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='https://richardkauli.com/portfolio'">CLOTHES</button><button onclick="location.href='https://richardkauli.com/archive/'">PORTFOLIO</button><button onclick="location.href='https://richardkauli.com/contact'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -575,8 +575,8 @@ body.menu-open .hamburger span:nth-child(3) {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com">HOME</a></li>
-<li><a href="https://www.richardkauli.com/portfolio">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/about/index.html
+++ b/about/index.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8" />
   <meta http-equiv="refresh" content="0; url=https://www.richardkauli.com/archive/" />
   <link rel="canonical" href="https://www.richardkauli.com/archive/" />
-  <title>Redirecting to Archive</title>
+  <title>Redirecting to Portfolio</title>
 </head>
 <body>
-  <p>This page has moved to <a href="https://www.richardkauli.com/archive/">Archive</a>.</p>
+  <p>This page has moved to <a href="https://www.richardkauli.com/archive/">Portfolio</a>.</p>
 </body>
 </html>

--- a/archive/2020EastRiverTitans/index.html
+++ b/archive/2020EastRiverTitans/index.html
@@ -741,8 +741,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -754,8 +754,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2021Backgrounds/index.html
+++ b/archive/2021Backgrounds/index.html
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -757,8 +757,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023AprFWBK/index.html
+++ b/archive/2023AprFWBK/index.html
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023AprZeus/index.html
+++ b/archive/2023AprZeus/index.html
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023AugJapanVillage/index.html
+++ b/archive/2023AugJapanVillage/index.html
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023DecParkMart/index.html
+++ b/archive/2023DecParkMart/index.html
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023OctFWBK/index.html
+++ b/archive/2023OctFWBK/index.html
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2023SepTosh/index.html
+++ b/archive/2023SepTosh/index.html
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2024FebFWBKLondon/index.html
+++ b/archive/2024FebFWBKLondon/index.html
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2024FebFWBKParis/index.html
+++ b/archive/2024FebFWBKParis/index.html
@@ -681,8 +681,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli/" target="_blank"></a>
 </div>
@@ -693,8 +693,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2024NovRunway27/index.html
+++ b/archive/2024NovRunway27/index.html
@@ -685,8 +685,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -697,8 +697,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2024OctFWBK/index.html
+++ b/archive/2024OctFWBK/index.html
@@ -694,8 +694,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -706,8 +706,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025AprFlier/index.html
+++ b/archive/2025AprFlier/index.html
@@ -690,8 +690,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -702,8 +702,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025AugFlier/index.html
+++ b/archive/2025AugFlier/index.html
@@ -690,8 +690,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -702,8 +702,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025DecFlier/index.html
+++ b/archive/2025DecFlier/index.html
@@ -690,8 +690,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -702,8 +702,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025JulFlier/index.html
+++ b/archive/2025JulFlier/index.html
@@ -691,8 +691,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -703,8 +703,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025MarFlier/index.html
+++ b/archive/2025MarFlier/index.html
@@ -720,8 +720,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -733,8 +733,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/2025MayFlier/index.html
+++ b/archive/2025MayFlier/index.html
@@ -690,8 +690,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -702,8 +702,8 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli/" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/archive/index.html
+++ b/archive/index.html
@@ -13,7 +13,7 @@
 <link href="https://www.richardkauli.com/favicon.png" rel="icon" type="image/png"/>
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
-<title>Richard Kauli - Archive</title>
+<title>Richard Kauli - Portfolio</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 @font-face {
@@ -633,9 +633,9 @@ a.project-link:hover img {
   filter: brightness(0) invert(1);
 }
 </style><link rel="canonical" href="https://www.richardkauli.com/archive/" />
-<meta property="og:title" content="ARCHIVE | Richard Kauli" />
+<meta property="og:title" content="PORTFOLIO | Richard Kauli" />
 <meta property="og:url" content="https://www.richardkauli.com/archive/" />
-<meta name="twitter:title" content="ARCHIVE | Richard Kauli" />
+<meta name="twitter:title" content="PORTFOLIO | Richard Kauli" />
 </head>
 <body style="margin-top: 0; padding-top: 0;">
 <div class="about-structured" style="max-width: 1000px; margin: 0 auto 12em auto; padding: 0 5vw; font-family: Courier, monospace; font-size: 1em; line-height: 1.6;">
@@ -691,7 +691,7 @@ a.project-link:hover img {
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2023 - 2025 Fashion Business Management AAS, Fashion Institute of Technology, New York, NY</span>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2025 - 2026 Advertising and Marketing Communications BS, Fashion Institute of Technology, New York, NY</span>
 </p></p></div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">CLOTHES</button><button onclick="location.href='../archive/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -700,8 +700,8 @@ a.project-link:hover img {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">CLOTHES</a></li>
+<li><a href="../archive/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/contact/index.html
+++ b/contact/index.html
@@ -699,7 +699,7 @@ body.menu-open .hamburger span:nth-child(3) {
     <button type="submit">Send</button>
   </form>
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">CLOTHES</button><button onclick="location.href='../archive/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -708,8 +708,8 @@ body.menu-open .hamburger span:nth-child(3) {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">CLOTHES</a></li>
+<li><a href="../archive/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@ model-viewer {
 </model-viewer>
 </div>
 <div class="button-panel">
-<a href="portfolio/" style="text-decoration: none; color: inherit;"><div>PORTFOLIO</div></a>
-<a href="archive/" style="text-decoration: none; color: inherit;"><div>ARCHIVE</div></a>
+<a href="portfolio/" style="text-decoration: none; color: inherit;"><div>CLOTHES</div></a>
+<a href="archive/" style="text-decoration: none; color: inherit;"><div>PORTFOLIO</div></a>
 <a href="contact/" style="text-decoration: none; color: inherit;"><div>CONTACT</div></a>
 </div>
 </div>

--- a/me/index.html
+++ b/me/index.html
@@ -5,7 +5,7 @@
 <head><link href="https://www.richardkauli.com/favicon.png" rel="icon" type="image/png"/>
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
-<title>Richard Kauli - Portfolio</title>
+<title>Richard Kauli - Clothes</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
 @font-face {
@@ -609,7 +609,7 @@ body.menu-open .hamburger span:nth-child(3) {
 
 </div>
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">CLOTHES</button><button onclick="location.href='../archive/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -618,8 +618,8 @@ body.menu-open .hamburger span:nth-child(3) {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="../index.html">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="../index.html">RICHARD KAULI</a></li><li><a href="../portfolio/">CLOTHES</a></li>
+<li><a href="../archive/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/ArsenalPants/index.html
+++ b/portfolio/ArsenalPants/index.html
@@ -719,8 +719,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/BirdBeanie/index.html
+++ b/portfolio/BirdBeanie/index.html
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/BirdBelt/index.html
+++ b/portfolio/BirdBelt/index.html
@@ -723,8 +723,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -736,8 +736,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/BrainBucketHat/index.html
+++ b/portfolio/BrainBucketHat/index.html
@@ -719,8 +719,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com/'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li
-  ><li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+  ><li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/CensoredGlasses/index.html
+++ b/portfolio/CensoredGlasses/index.html
@@ -733,8 +733,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -746,8 +746,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/CensoredShirt/index.html
+++ b/portfolio/CensoredShirt/index.html
@@ -725,8 +725,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -738,8 +738,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/ClearPocketPants2/index.html
+++ b/portfolio/ClearPocketPants2/index.html
@@ -728,8 +728,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -741,8 +741,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/EyeSeeYouButtonUp/index.html
+++ b/portfolio/EyeSeeYouButtonUp/index.html
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/FireFighterHat/index.html
+++ b/portfolio/FireFighterHat/index.html
@@ -733,8 +733,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -746,8 +746,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/FlowerVision/index.html
+++ b/portfolio/FlowerVision/index.html
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/GalaxyHoodie/index.html
+++ b/portfolio/GalaxyHoodie/index.html
@@ -736,8 +736,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -749,8 +749,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/GalaxyPants/index.html
+++ b/portfolio/GalaxyPants/index.html
@@ -731,8 +731,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/JetpackBackPack/index.html
+++ b/portfolio/JetpackBackPack/index.html
@@ -731,8 +731,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/KidsuperTee/index.html
+++ b/portfolio/KidsuperTee/index.html
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -745,8 +745,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/LockedUpDress/index.html
+++ b/portfolio/LockedUpDress/index.html
@@ -731,8 +731,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/MattressBackpack/index.html
+++ b/portfolio/MattressBackpack/index.html
@@ -737,8 +737,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -750,8 +750,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/MillionDollarBackpack/index.html
+++ b/portfolio/MillionDollarBackpack/index.html
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/MoneyDuffelBag/index.html
+++ b/portfolio/MoneyDuffelBag/index.html
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/MoneySuit/index.html
+++ b/portfolio/MoneySuit/index.html
@@ -731,8 +731,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/NudeScarf/index.html
+++ b/portfolio/NudeScarf/index.html
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/OneWayHat/index.html
+++ b/portfolio/OneWayHat/index.html
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/RunningSweater/index.html
+++ b/portfolio/RunningSweater/index.html
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -745,8 +745,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/RunningSweatpants/index.html
+++ b/portfolio/RunningSweatpants/index.html
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/SleepySet/index.html
+++ b/portfolio/SleepySet/index.html
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -752,8 +752,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/StopSignBackpack/index.html
+++ b/portfolio/StopSignBackpack/index.html
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/StopSignMiniBag/index.html
+++ b/portfolio/StopSignMiniBag/index.html
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/TVBackpack/index.html
+++ b/portfolio/TVBackpack/index.html
@@ -719,8 +719,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -732,8 +732,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/TeddyHat/index.html
+++ b/portfolio/TeddyHat/index.html
@@ -726,8 +726,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/TeddySet/index.html
+++ b/portfolio/TeddySet/index.html
@@ -733,8 +733,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -746,8 +746,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/TeddySweater/index.html
+++ b/portfolio/TeddySweater/index.html
@@ -727,8 +727,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div style="height:4em;"></div>
 <div class="bottom-nav">
 <button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button>
-<button onclick="location.href='https://www.richardkauli.com/portfolio/'">PORTFOLIO</button>
-<button onclick="location.href='https://www.richardkauli.com/archive/'">ARCHIVE</button>
+<button onclick="location.href='https://www.richardkauli.com/portfolio/'">CLOTHES</button>
+<button onclick="location.href='https://www.richardkauli.com/archive/'">PORTFOLIO</button>
 <button onclick="location.href='https://www.richardkauli.com/contact/'">CONTACT</button>
 <a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a>
 </div>
@@ -740,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
 <li><a href="https://www.richardkauli.com/">RICHARD KAULI</a></li>
-<li><a href="https://www.richardkauli.com/portfolio/">PORTFOLIO</a></li>
-<li><a href="https://www.richardkauli.com/archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com/portfolio/">CLOTHES</a></li>
+<li><a href="https://www.richardkauli.com/archive/">PORTFOLIO</a></li>
 <li><a href="https://www.richardkauli.com/contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -13,7 +13,7 @@
 <link href="https://www.richardkauli.com/favicon.png" rel="icon" type="image/png"/>
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
-<title>Richard Kauli - Portfolio</title>
+<title>Richard Kauli - Clothes</title>
 <meta property="og:image" content="https://www.richardkauli.com/HELLO2.glb" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
@@ -826,7 +826,7 @@ body::-webkit-scrollbar {
 <div style="height: 1em;"></div>
 </div>
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">CLOTHES</button><button onclick="location.href='../archive/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -835,8 +835,8 @@ body::-webkit-scrollbar {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">CLOTHES</a></li>
+<li><a href="../archive/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/portfolio/index_old.html
+++ b/portfolio/index_old.html
@@ -5,7 +5,7 @@
 <head><link href="https://www.richardkauli.com/favicon.png" rel="icon" type="image/png"/>
 <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" type="module"></script>
 <meta charset="utf-8"/>
-<title>Richard Kauli - Portfolio</title>
+<title>Richard Kauli - Clothes</title>
 <meta property="og:image" content="https://www.richardkauli.com/HELLO2.glb" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <style>
@@ -843,7 +843,7 @@ body::-webkit-scrollbar {
 <div style="height: 1em;"></div>
 </div>
 </div>
-<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">PORTFOLIO</button><button onclick="location.href='../archive/'">ARCHIVE</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
+<div class="bottom-nav"><button onclick="location.href='https://www.richardkauli.com'">RICHARD KAULI</button><button onclick="location.href='../portfolio/'">CLOTHES</button><button onclick="location.href='../archive/'">PORTFOLIO</button><button onclick="location.href='../contact/'">CONTACT</button><a class="instagram-icon" href="https://www.instagram.com/richard.kauli" target="_blank"></a></div>
 <!-- Mobile Hamburger Menu -->
 <div class="hamburger" id="hamburger">
 <span></span>
@@ -852,8 +852,8 @@ body::-webkit-scrollbar {
 </div>
 <div class="mobile-menu-overlay" id="menuOverlay">
 <ul>
-<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">PORTFOLIO</a></li>
-<li><a href="../archive/">ARCHIVE</a></li>
+<li><a href="https://www.richardkauli.com">RICHARD KAULI</a></li><li><a href="../portfolio/">CLOTHES</a></li>
+<li><a href="../archive/">PORTFOLIO</a></li>
 <li><a href="../contact/">CONTACT</a></li>
 <li><a class="mobile-menu-link" href="https://www.instagram.com/richard.kauli" target="_blank"><div class="instagram-icon"></div></a></li>
 </ul>

--- a/scripts/rename-archive-and-portfolio-labels.mjs
+++ b/scripts/rename-archive-and-portfolio-labels.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const EXCLUDED_DIRS = new Set(['.git', 'node_modules']);
+const TARGET_EXTENSIONS = new Set(['.html', '.htm']);
+
+const REPLACEMENTS = [
+  { from: 'PORTFOLIO', to: 'CLOTHES' },
+  { from: 'Portfolio', to: 'Clothes' },
+  { from: 'ARCHIVE', to: 'PORTFOLIO' },
+  { from: 'Archive', to: 'Portfolio' },
+];
+
+function applyLabelReplacements(input, counts) {
+  let output = input;
+  const placeholders = [
+    { token: '__TMP_UPPER_PORTFOLIO__', from: 'PORTFOLIO', to: 'CLOTHES' },
+    { token: '__TMP_TITLE_PORTFOLIO__', from: 'Portfolio', to: 'Clothes' },
+    { token: '__TMP_UPPER_ARCHIVE__', from: 'ARCHIVE', to: 'PORTFOLIO' },
+    { token: '__TMP_TITLE_ARCHIVE__', from: 'Archive', to: 'Portfolio' },
+  ];
+
+  for (const { token, from } of placeholders) {
+    const regex = new RegExp(from, 'g');
+    const matches = output.match(regex);
+    if (matches) {
+      counts[from] += matches.length;
+      output = output.replace(regex, token);
+    }
+  }
+
+  output = output
+    .replace(/__TMP_UPPER_PORTFOLIO__/g, 'CLOTHES')
+    .replace(/__TMP_TITLE_PORTFOLIO__/g, 'Clothes')
+    .replace(/__TMP_UPPER_ARCHIVE__/g, 'PORTFOLIO')
+    .replace(/__TMP_TITLE_ARCHIVE__/g, 'Portfolio');
+
+  return output;
+}
+
+function processHtmlSegment(segment, counts) {
+  // Replace visible tag text nodes: > ... <
+  segment = segment.replace(/>([^<]+)</g, (match, innerText) => {
+    const replaced = applyLabelReplacements(innerText, counts);
+    return `>${replaced}<`;
+  });
+
+
+  // Replace OG/Twitter title meta content
+  segment = segment.replace(
+    /<meta\s+([^>]*?(?:property|name)\s*=\s*["'](?:og:title|twitter:title)["'][^>]*?)>/gi,
+    (metaTag, attrs) => {
+      const contentRegex = /(content\s*=\s*["'])([^"']*)(["'])/i;
+      if (!contentRegex.test(attrs)) return metaTag;
+      const updatedAttrs = attrs.replace(contentRegex, (full, start, value, end) => {
+        const replaced = applyLabelReplacements(value, counts);
+        return `${start}${replaced}${end}`;
+      });
+      return `<meta ${updatedAttrs}>`;
+    }
+  );
+
+  return segment;
+}
+
+function processHtmlContent(content, counts) {
+  // Protect script/style blocks from text replacement.
+  const blocks = [];
+  let stripped = content.replace(/<(script|style)\b[\s\S]*?<\/\1>/gi, (block) => {
+    const token = `__BLOCK_${blocks.length}__`;
+    blocks.push(block);
+    return token;
+  });
+
+  stripped = processHtmlSegment(stripped, counts);
+
+  return stripped.replace(/__BLOCK_(\d+)__/g, (_, idx) => blocks[Number(idx)]);
+}
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!EXCLUDED_DIRS.has(entry.name)) {
+        files.push(...(await walk(fullPath)));
+      }
+      continue;
+    }
+
+    const ext = path.extname(entry.name).toLowerCase();
+    if (TARGET_EXTENSIONS.has(ext)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function main() {
+  const files = await walk(ROOT);
+  const totals = Object.fromEntries(REPLACEMENTS.map((r) => [r.from, 0]));
+  const changed = [];
+
+  for (const file of files) {
+    const original = await fs.readFile(file, 'utf8');
+    const fileCounts = Object.fromEntries(REPLACEMENTS.map((r) => [r.from, 0]));
+    const updated = processHtmlContent(original, fileCounts);
+
+    if (updated !== original) {
+      await fs.writeFile(file, updated, 'utf8');
+      const rel = path.relative(ROOT, file);
+      changed.push({ rel, fileCounts });
+      for (const key of Object.keys(totals)) {
+        totals[key] += fileCounts[key];
+      }
+    }
+  }
+
+  console.log('Rename labels report');
+  console.log(`Files changed: ${changed.length}`);
+  for (const item of changed) {
+    const entries = Object.entries(item.fileCounts)
+      .filter(([, count]) => count > 0)
+      .map(([label, count]) => `${label}:${count}`)
+      .join(', ');
+    console.log(`- ${item.rel}${entries ? ` (${entries})` : ''}`);
+  }
+
+  console.log('Totals:');
+  for (const [label, count] of Object.entries(totals)) {
+    console.log(`  ${label} -> ${count}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Update the visible site language so every instance of “Portfolio” becomes “Clothes” and every instance of “Archive” becomes “Portfolio” while keeping URLs and site structure intact.  
- Make surgical text-only changes across navigation, buttons, headings, breadcrumbs and metadata to avoid breaking links or renaming directories.  

### Description
- Added a safe Node script `scripts/rename-archive-and-portfolio-labels.mjs` that walks the repo and replaces visible HTML text nodes and metadata (including `og:title` and `twitter:title`) while skipping `script`/`style` blocks and code identifiers.  
- Replacement mappings implemented: `PORTFOLIO` → `CLOTHES`, `Portfolio` → `Clothes`, `ARCHIVE` → `PORTFOLIO`, `Archive` → `Portfolio`.  
- Applied replacements to site HTML; updated 56 HTML files (navigation, footers, buttons, titles, and meta) and added the script file, preserving all `href` targets and directory names.  
- The script uses temporary placeholders to avoid overlapping replacements and logs per-file and total counts.  

### Testing
- Ran the script with `node scripts/rename-archive-and-portfolio-labels.mjs` and observed the reported changes and totals (files changed: 56; totals show upper/lowercase replacements).  
- Verified metadata updates via targeted scans for `<title>`, `og:title`, and `twitter:title` and confirmed title mappings (e.g. Archive page title → `Portfolio`, Portfolio pages → `Clothes`).  
- Started a local server with `python3 -m http.server 8000` and confirmed key routes responded (`/`, `/portfolio/`, `/archive/`, `/contact/`) and captured a homepage screenshot to validate navigation labels visually.  
- Final validation: no remaining visible `Archive`/`ARCHIVE` labels detected and `Portfolio`/`PORTFOLIO` labels are present where expected (these are former Archive labels now renamed to `Portfolio`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994908694488328a99281818f1b6848)