### PR TITLE
Fix swapped section labels and align archive link icons

### DIFF
--- a/archive/index.html
+++ b/archive/index.html
@@ -198,6 +198,18 @@
 }
 
 
+.project-link.with-icon {
+  display: flex !important;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.project-link.with-icon img {
+  margin-left: auto !important;
+  flex: 0 0 auto;
+}
+
 .bottom-nav button {
   transition: transform 0.2s ease, color 0.3s ease;
 }
@@ -640,36 +652,36 @@ a.project-link:hover img {
 <body style="margin-top: 0; padding-top: 0;">
 <div class="about-structured" style="max-width: 1000px; margin: 0 auto 12em auto; padding: 0 5vw; font-family: Courier, monospace; font-size: 1em; line-height: 1.6;">
 <p><strong>Group Projects:</strong>
-<a class="project-link" href="https://2022-artshow.freeinquotes.com/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_blank">2022 Jul SEE HOW FREE YOU REALLY ARE - Fashion and Web3 Pop-Up, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="https://2022-artshow.freeinquotes.com/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_blank">2022 Jul SEE HOW FREE YOU REALLY ARE - Fashion and Web3 Pop-Up, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2022 Nov Piece Unik - Fashion Experience and Auction, Los Angeles, CA</span>
-<a class="project-link" href="https://www.youtube.com/watch?v=ADoRabr_ZRU" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_blank">2023 Nov UNDER TRACKS_ - Short film, Osaka, Japan<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2023DecParkMart/" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2023 Dec ParkMart - Fashion Pop-Up, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="https://www.youtube.com/watch?v=ADoRabr_ZRU" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_blank">2023 Nov UNDER TRACKS_ - Short film, Osaka, Japan<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2023DecParkMart/" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2023 Dec ParkMart - Fashion Pop-Up, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2024 Sep Piece Unik - Fashion Experience and Auction, New York, NY</span>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2025 Aug Slow Driving Club - Motorcycle Enthusiast Club, New York, NY</span>
 <div style="margin-top:1em;"></div><strong>Fashion Shows:</strong><div style="margin-bottom:1em;"></div>
-<a class="project-link" href="/archive/2023AprZeus/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Apr ZEUS - CENSORED SS23 Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2023AprFWBK/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Apr Fashion Week Brooklyn - CENSORED SS23 Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2023AprZeus/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Apr ZEUS - CENSORED SS23 Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2023AprFWBK/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Apr Fashion Week Brooklyn - CENSORED SS23 Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2023 Apr ZEUS - CENSORED SS23 Collection, Brooklyn, NY</span>
-<a class="project-link" href="/archive/2023AugJapanVillage/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Aug Japan Village - Million Dollar Bag Debut, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2023SepTosh/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Sep TOSH - CASH ME IF YOU CAN, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2023OctFWBK/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Oct Fashion Week Brooklyn - POWER NAP Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2024FebFWBKLondon/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Feb Fashion Week Brooklyn - POWER NAP Collection, London, United Kingdom<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2023AugJapanVillage/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Aug Japan Village - Million Dollar Bag Debut, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2023SepTosh/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Sep TOSH - CASH ME IF YOU CAN, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2023OctFWBK/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2023 Oct Fashion Week Brooklyn - POWER NAP Collection, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2024FebFWBKLondon/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Feb Fashion Week Brooklyn - POWER NAP Collection, London, United Kingdom<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2024 Feb Fashion Week Brooklyn - POWER NAP Collection, Paris, France</span>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2024 Apr Fashion Week Brooklyn - PLUGGED IN Collection, Brooklyn, NY</span>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Oct Fashion Week Brooklyn - PLUGGED IN TOO Collection, Brooklyn, NY</span>
-<a class="project-link" href="/archive/2024NovRunway27/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Nov Runway 27 - TV Backpack, Fashion Institute of Technology, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2024NovRunway27/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2024 Nov Runway 27 - TV Backpack, Fashion Institute of Technology, New York, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <p><strong>Books/Zines:</strong>
-<a class="project-link" href="/archive/2020EastRiverTitans/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2020 Apr East River Titans, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2021Backgrounds/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2021 Mar Backgrounds, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2020EastRiverTitans/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2020 Apr East River Titans, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2021Backgrounds/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2021 Mar Backgrounds, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 </p>
 
 <p><strong>Event Fliers:</strong>
-<a class="project-link" href="/archive/2025MarFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Mar Housewarming, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2025AprFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Apr #2, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2025MayFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 May Prospect Park BBQ, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
-<a class="project-link" href="/archive/2025JulFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Jul The Fourth Gathering, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2025MarFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Mar Housewarming, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2025AprFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Apr #2, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2025MayFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 May Prospect Park BBQ, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2025JulFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Jul The Fourth Gathering, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 <span class="project-link" style="display: block; padding-left: 5.5em; text-indent: -5.5em">2025 Aug 22nd Birthday, Brooklyn, NY</span>
-<a class="project-link" href="/archive/2025DecFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Dec Real Ones Pt 6, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
+<a class="project-link with-icon" href="/archive/2025DecFlier/" style="display: block; padding-left: 5.5em; text-indent: -5.5em" target="_self">2025 Dec Real Ones Pt 6, Brooklyn, NY<img alt="Link Icon" src="link.png" style="width: 22px; height: 11px; vertical-align: middle; margin-left: 6px;"/></a>
 </p>
 
 <p><strong>Brands:</strong>

--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@ model-viewer {
 </model-viewer>
 </div>
 <div class="button-panel">
-<a href="portfolio/" style="text-decoration: none; color: inherit;"><div>CLOTHES</div></a>
-<a href="archive/" style="text-decoration: none; color: inherit;"><div>PORTFOLIO</div></a>
+<a href="portfolio/" style="text-decoration: none; color: inherit;"><div>PORTFOLIO</div></a>
+<a href="archive/" style="text-decoration: none; color: inherit;"><div>CLOTHES</div></a>
 <a href="contact/" style="text-decoration: none; color: inherit;"><div>CONTACT</div></a>
 </div>
 </div>


### PR DESCRIPTION
### Motivation
- Correct the homepage navigation labels so the `/portfolio/` and `/archive/` links display the intended section names, and make archive page link icons sit flush at the right edge of the link hitbox for clearer click targets.

### Description
- Swapped the two button labels in `index.html` so the `portfolio/` link now reads `PORTFOLIO` and the `archive/` link now reads `CLOTHES`.
- Added a `.project-link.with-icon` CSS block to `archive/index.html` that uses a flex layout and forces the icon image to the far right with `margin-left: auto`.
- Updated archive page anchor elements that include the link image to use the new `with-icon` modifier so only linked rows receive the right-aligned icon behavior.
- Files changed: `index.html` and `archive/index.html`.

### Testing
- Located affected files with `rg` and inspected context with `sed`/`nl` to confirm the changes were applied, and those inspections completed successfully.
- Applied the edits via the Python replacement scripts and verified differences with `git diff -- index.html archive/index.html`, which showed the intended updates.
- Committed the changes with `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f530705194832890cfbe9406504ee1)